### PR TITLE
add length() method to LuaValue

### DIFF
--- a/include/LuaValue.h
+++ b/include/LuaValue.h
@@ -267,7 +267,7 @@ namespace lua {
         double toDouble() const {
             return to<double>();
         }
-        
+
         /// Will get pointer casted to given template type
         ///
         /// @return Pointer staticaly casted to given template type
@@ -345,6 +345,10 @@ namespace lua {
             lua_settable(_stack->state, _stack->top + _stack->pushed - _stack->grouped);
         }
         
+        int length() const {
+            return lua_objlen(_stack->state, _stack->top + _stack->pushed - _stack->grouped);
+        }
+
         template<typename K>
         void set(K key, const std::string& value) const {
             setString<lua::String>(key, value);


### PR DESCRIPTION
returns the length of strings and tables (so long as the tables don't include nil)
